### PR TITLE
feat(footer): add simple footer with primary background and white text

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 export default function Footer() {
   return (
-    <footer className="bg-primary text-center p-4 text-sm text-white">
-      @ 2025 PetAdopt. All rights reserved
+    <footer className="bg-primary text-white text-center text-xs py-4">
+      © 2025 PetAdopt | Designed for Noroff FED2
     </footer>
   );
 }


### PR DESCRIPTION
- implement <Footer> component with centered © 2025 text
- uses bg-primary and text-white as per design system
- links/icons (Contact, GitHub, LinkedIn) excluded for now
  ∙ can be added later if time allows