### PR TITLE
feat(loader): implement centered spinner with #F5F5F5 bg

### DIFF
--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -1,0 +1,12 @@
+export default function Loader({ size = 48 }) {
+  return (
+    /* full-screen overlay */
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-#f5f5f5">
+      {/* selve spinneren */}
+      <div
+        className="rounded-full border-4 border-primary border-t-transparent animate-spin"
+        style={{ width: size, height: size }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
- add full-screen <Loader> component with default 48×48px size
- centered spinner with primary border and transparent top
- background color set to #F5F5F5 for design consistency