### PR TITLE
feat(auth): implement robust protected routes and auth state hydration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router-dom";
 import Layout from "./layout/Layout.jsx";
 
 /* pages */
+import ProtectedRoute from "./components/ProtectedRoute"; // <-- IMPORT
 import CreatePet from "./pages/CreatePet";
 import EditPet from "./pages/EditPet";
 import Home from "./pages/Home";
@@ -18,9 +19,25 @@ function App() {
         <Route path="pet/:id" element={<PetDetail />} />
         <Route path="login" element={<Login />} />
         <Route path="register" element={<Register />} />
-        <Route path="create" element={<CreatePet />} />
-        <Route path="edit/:id" element={<EditPet />} />
-      </Route>{" "}
+
+        {/* Protected routes */}
+        <Route
+          path="create"
+          element={
+            <ProtectedRoute>
+              <CreatePet />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="edit/:id"
+          element={
+            <ProtectedRoute>
+              <EditPet />
+            </ProtectedRoute>
+          }
+        />
+      </Route>
     </Routes>
   );
 }

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,16 @@
+import { Navigate } from "react-router-dom";
+import { useAuthStore } from "../store/authStore";
+
+// Wrapper for beskyttede ruter
+export default function ProtectedRoute({ children }) {
+  const user = useAuthStore((state) => state.user);
+  const token = useAuthStore((state) => state.token);
+
+  // Hvis ikke innlogget, redirect til login
+  if (!user || !token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  // Hvis innlogget, vis child-komponent (f.eks. Create/Edit)
+  return children;
+}

--- a/src/hooks/useInitAuth.js
+++ b/src/hooks/useInitAuth.js
@@ -1,0 +1,8 @@
+import { useEffect } from "react";
+import { useAuthStore } from "../store/authStore";
+
+export function useInitAuth() {
+  useEffect(() => {
+    useAuthStore.getState().initAuth();
+  }, []);
+}

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -1,8 +1,10 @@
 import { Outlet } from "react-router-dom";
 import Footer from "../components/Footer";
 import Navbar from "../components/Navbar";
+import { useInitAuth } from "../hooks/useInitAuth"; // <-- LEGG TIL DENNE
 
 export default function Layout() {
+  useInitAuth(); // <-- KALL DEN ALLER ØVERST
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -22,7 +22,7 @@ export default function Login() {
     try {
       const result = await login(data);
       useAuthStore.getState().login(result.data, result.token);
-      navigate("/"); // dashboard om tid
+      window.location.href = "/"; //dashbord om tid//
     } catch (error) {
       setError("email", { type: "manual", message: "Invalid credentials" });
     } finally {

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -22,7 +22,7 @@ export default function Register() {
     try {
       const result = await registerUser(data);
       useAuthStore.getState().login(result.data, result.token);
-      navigate("/"); // Endre til ønsket redirect!
+      window.location.href = "/"; // Dashboard om tid
     } catch (error) {
       setError("email", { type: "manual", message: "Registration failed" });
     } finally {


### PR DESCRIPTION
- Added ProtectedRoute component to restrict access to /create and /edit/:id for authenticated users only
- Introduced useInitAuth hook and called it in Layout to hydrate auth state from sessionStorage on app load
- Updated login and register to trigger full page reload after success to ensure correct auth state
- Ensured all protected routes and UI logic reflect latest auth state seamlessly
- Small improvements and cleanup across app.jsx, layout.jsx, login.jsx, register.jsx

This improves authentication reliability, solves race conditions after login/register, and guarantees protected pages are only accessible when logged in.